### PR TITLE
[semver:minor] Allow using the DD_SITE environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2021-11-09
+## Added
+    - Can now use `DD_SITE` to pass the datadog site.
+
 ## [3.0.0] - 2021-09-16
 ### Changed
     - agent setup command documentation

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -10,7 +10,7 @@ parameters:
     default: "7"
   site:
     type: string
-    description: The datadog site to send data to
+    description: The datadog site to send data to. If the environmental variable DD_SITE is set that will take preference.
     default: "datadoghq.com"
 steps:
   - run:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -10,7 +10,7 @@ parameters:
     default: "7"
   site:
     type: string
-    description: The datadog site to send data to. If the environmental variable DD_SITE is set that will take preference.
+    description: The datadog site to send data to. If the environment variable DD_SITE is set that will take preference.
     default: "datadoghq.com"
 steps:
   - run:

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -1,5 +1,10 @@
 Install() {
     PARAM_DD_API_KEY=$(eval echo "\$$PARAM_DD_API_KEY")
+
+    if [[ -z "${DD_SITE}" ]]; then
+        PARAM_DD_SITE=${DD_SITE}
+    fi
+
     DD_API_KEY=${PARAM_DD_API_KEY} DD_AGENT_MAJOR_VERSION=${PARAM_DD_AGENT_MAJOR_VERSION} DD_SITE=${PARAM_DD_SITE} \
         DD_HOSTNAME="none" DD_INSTALL_ONLY="true" DD_APM_ENABLED="true" \
         bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"


### PR DESCRIPTION
What does this PR do?
------------
Allow using the environmental variable `DD_SITE` to provide the Datadog site to use. This will take preference over the one provided in the parameters.

Motivation
-----
Issue: #5 