### PR TITLE
[semver:patch] Correctly check if DD_SITE is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2021-11-10
+## Fixed
+    - Typo stopping the usage of `DD_SITE` to set the Datadog site.
+
 ## [3.1.0] - 2021-11-09
 ## Added
-    - Can now use `DD_SITE` to pass the datadog site.
+    - Can now use `DD_SITE` to pass the Datadog site.
 
 ## [3.0.0] - 2021-09-16
 ### Changed

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -1,7 +1,7 @@
 Install() {
     PARAM_DD_API_KEY=$(eval echo "\$$PARAM_DD_API_KEY")
 
-    if [[ -z "${DD_SITE}" ]]; then
+    if [[ -n "${DD_SITE}" ]]; then
         PARAM_DD_SITE=${DD_SITE}
     fi
 


### PR DESCRIPTION
What does this PR do?
---------

Fix the comparison in the setup function to use `DD_SITE` if it set. Currently it does the opposite.