### PR TITLE
Split the setup command into start+wait

### DIFF
--- a/src/commands/start.yml
+++ b/src/commands/start.yml
@@ -1,4 +1,4 @@
-description: "Installs and starts the Datadog Agent"
+description: "Starts the Datadog Agent"
 parameters:
   api_key:
     type: env_var_name
@@ -13,7 +13,11 @@ parameters:
     description: The datadog site to send data to. If the environment variable DD_SITE is set that will take preference.
     default: "datadoghq.com"
 steps:
-  - start:
-      api_key: <<parameters.api_key>>
-      agent_major_version: <<parameters.agent_major_version>>
-      site: <<parameters.site>>
+  - run:
+      environment:
+        PARAM_DD_API_KEY: <<parameters.api_key>>
+        PARAM_DD_AGENT_MAJOR_VERSION: <<parameters.agent_major_version>>
+        PARAM_DD_SITE: <<parameters.site>>
+      name: Install and start the Datadog Agent
+      working_directory: /tmp
+      command: <<include(scripts/start.sh)>>

--- a/src/commands/wait.yml
+++ b/src/commands/wait.yml
@@ -1,0 +1,10 @@
+description: "Wait for the Datadog Agent"
+steps:
+  - run:
+      environment:
+        PARAM_DD_API_KEY: <<parameters.api_key>>
+        PARAM_DD_AGENT_MAJOR_VERSION: <<parameters.agent_major_version>>
+        PARAM_DD_SITE: <<parameters.site>>
+      name: Install and start the Datadog Agent
+      working_directory: /tmp
+      command: <<include(scripts/wait.sh)>>

--- a/src/examples/ci-visibility-example.yml
+++ b/src/examples/ci-visibility-example.yml
@@ -8,10 +8,12 @@ usage:
         - image: your-image
       steps:
         - checkout
-        - datadog-agent/setup:
+        - datadog-agent/start:
             agent_major_version: "7"
             api_key: DATADOG_API_KEY
             site: datadoghq.com
+        - run: make
+        - datadog-agent/wait
         - run: make test
         - datadog-agent/stop
   orbs:

--- a/src/scripts/start.sh
+++ b/src/scripts/start.sh
@@ -1,4 +1,4 @@
-Install() {
+Start() {
     PARAM_DD_API_KEY=$(eval echo "\$$PARAM_DD_API_KEY")
 
     if [[ -n "${DD_SITE}" ]]; then
@@ -12,28 +12,11 @@ Install() {
     if [ "$UID" = "0" ]; then export SUDO=''; else export SUDO='sudo'; fi
     $SUDO find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
     $SUDO service datadog-agent start
-
-    set +e
-    attempts=0
-
-    until [[ $attempts -eq 10 ]] || $SUDO datadog-agent health; do
-        attempts=$((attempts+1))
-        sleep_time=$(( attempts*5 < 30 ? attempts*5 : 30 ))
-        echo "Waiting for agent to start up sleeping for ${sleep_time} seconds"
-        sleep $sleep_time
-    done
-
-    if [[ $attempts -eq 10 ]]; then
-        echo "Could not start the agent"
-        exit 1
-    else
-        echo "Agent is ready"
-    fi
 }
 
 # Will not run if sourced for bats-core tests.
 # View src/tests for more information.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
-    Install
+    Start
 fi

--- a/src/scripts/wait.sh
+++ b/src/scripts/wait.sh
@@ -1,20 +1,21 @@
 Wait() {
     set +e
     attempts=0
+    max_attempts=240
 
-    until [[ $attempts -eq 10 ]] || $SUDO datadog-agent health; do
-        attempts=$((attempts+1))
-        sleep_time=$(( attempts*5 < 30 ? attempts*5 : 30 ))
-        echo "Waiting for agent to start up sleeping for ${sleep_time} seconds"
-        sleep $sleep_time
+    until [[ $attempts -eq $max_attempts ]]; do
+      if $SUDO datadog-agent health; then
+        echo "Agent is ready"
+        exit 0
+      fi
+
+      attempts=$((attempts+1))
+      echo "Waiting for agent to start, attempt no. ${attempts}"
+      sleep 1
     done
 
-    if [[ $attempts -eq 10 ]]; then
-        echo "Could not start the agent"
-        exit 1
-    else
-        echo "Agent is ready"
-    fi
+    echo "Could not start the agent"
+    exit 1
 }
 
 # Will not run if sourced for bats-core tests.

--- a/src/scripts/wait.sh
+++ b/src/scripts/wait.sh
@@ -1,0 +1,25 @@
+Wait() {
+    set +e
+    attempts=0
+
+    until [[ $attempts -eq 10 ]] || $SUDO datadog-agent health; do
+        attempts=$((attempts+1))
+        sleep_time=$(( attempts*5 < 30 ? attempts*5 : 30 ))
+        echo "Waiting for agent to start up sleeping for ${sleep_time} seconds"
+        sleep $sleep_time
+    done
+
+    if [[ $attempts -eq 10 ]]; then
+        echo "Could not start the agent"
+        exit 1
+    else
+        echo "Agent is ready"
+    fi
+}
+
+# Will not run if sourced for bats-core tests.
+# View src/tests for more information.
+ORB_TEST_ENV="bats-core"
+if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
+    Wait
+fi

--- a/src/tests/setup.bats
+++ b/src/tests/setup.bats
@@ -4,11 +4,13 @@
 # DD_SITE
 
 setup() {
-    source ./src/scripts/setup.sh
+    source ./src/scripts/start.sh
+    source ./src/scripts/wait.sh
 }
 
 @test '1: Check agent installed and running' {
-    Install
+    Start
+	Wait
     if [ "$UID" = "0" ]; then export SUDO=''; else export SUDO='sudo'; fi
     $SUDO datadog-agent status # If the agent did not install and is not running this will fail
 }


### PR DESCRIPTION
The current setup command could take up to 30 seconds. 
By splitting we can go on with other setup work before checking for the agent to be active and optimize the wait time.

cc @nbelzer