### PR TITLE
[semver:patch] Deprecate Orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# [DEPRECATED] Datadog Agent Action
+
+![Deprecated](https://img.shields.io/badge/status-deprecated-red.svg)
+
+## Deprecation notice
+
+This project is no longer maintained. The recommended way of using [Test Visibility](https://docs.datadoghq.com/tests/) in CircleCI is via [Agentless Mode](https://docs.datadoghq.com/tests/setup/javascript/?tab=othercloudciprovider#configuring-reporting-method).
+
 # datadog-agent-orb
 
 [![CircleCI Build Status](https://circleci.com/gh/DataDog/datadog-agent-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/datadog/datadog-agent-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/datadog/agent.svg)](https://circleci.com/developer/orbs/orb/datadog/agent) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/datadog/datadog-agent-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 description: >
-  Installs and runs the Datadog Agent in the background to be used to report tests instrumented with the CI Visibility product.
-  For the command to work the image running it must have `curl` installed.
+  This orb is deprecated. Please use Agentless Mode instead: https://docs.datadoghq.com/tests/setup/javascript/?tab=othercloudciprovider#configuring-reporting-method.
 display:
-  home_url: "https://docs.datadoghq.com/continuous_integration/"
+  home_url: "https://docs.datadoghq.com/tests/"
   source_url: "https://github.com/DataDog/datadog-agent-orb"

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -34,6 +34,8 @@ Install() {
 # Will not run if sourced for bats-core tests.
 # View src/tests for more information.
 ORB_TEST_ENV="bats-core"
+echo "WARNING: This orb is deprecated and will be removed after January 31, 2025. Please use Agentless Mode. Read more in https://docs.datadoghq.com/tests/setup/"
+
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
     Install
 fi


### PR DESCRIPTION
Its removal date has been set to January 31st, 2025. Feel free to propose another date.